### PR TITLE
rtas_errd: Don't run the service in LXC

### DIFF
--- a/scripts/rtas_errd.service
+++ b/scripts/rtas_errd.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=ppc64-diag rtas_errd (platform error handling) Service
+ConditionVirtualization=!lxc
 ConditionPathExists=|/proc/ppc64/rtas/error_log
 ConditionPathExists=|/proc/ppc64/error_log
 After=syslog.target


### PR DESCRIPTION
It just fails to start in unprivileged containers

Signed-off-by: Balint Reczey <balint.reczey@canonical.com>