### PR TITLE
Fix opal-dump-parse  manpage

### DIFF
--- a/opal-dump-parse/opal-dump-parse.8
+++ b/opal-dump-parse/opal-dump-parse.8
@@ -8,7 +8,7 @@
 opal-dump-parse \- Parse OPAL System dump
 .SH SYNOPSIS
 .B opal-dump-parse
-[ \fB\-l\fR | \fB\-h\fR | \fB\-s\fR \f id\fR | \fB\-o\fR \f file\R ] <SYSDUMP>
+[ \fB\-l\fR | \fB\-h\fR | \fB\-s\fR \fI\,id\fR | \fB\-o\fR \fI\,file\fR ] <SYSDUMP>
 .SH DESCRIPTION
 On Power Systems service processor (FSP) generates System dump (SYSDUMP) during
 system crash. On PowerKVM machine SYSDUMP contains OPAL logs. This tool helps to


### PR DESCRIPTION
Fixed the "a space character is not allowed in an escape name" problem to avoid
a lintian issue while generating man pages in Debian.