### PR TITLE
Use a string literal for the format argument of mvwprintw and mvprintw

### DIFF
--- a/lpd/lp_diag.c
+++ b/lpd/lp_diag.c
@@ -653,11 +653,11 @@ UI_help(MENU *my_menu)
 	}
 
 	if (!strcmp(desc, "ident"))
-		mvwprintw(my_text_win, 0, 0, help1);
+		mvwprintw(my_text_win, 0, 0, "%s", help1);
 	else if (!strcmp(desc, "attn"))
-		mvwprintw(my_text_win, 0, 0, help2);
+		mvwprintw(my_text_win, 0, 0, "%s", help2);
 	else
-		mvwprintw(my_text_win, 0, 0, help3);
+		mvwprintw(my_text_win, 0, 0, "%s", help3);
 
 	wrefresh(my_text_win);
 
@@ -1127,8 +1127,8 @@ startup_window(void)
 	}
 
 	mvprintw(0, 0, "SERVICE INDICATORS VERSION %s", VERSION);
-	mvprintw(2, 0, msg1);
-	mvprintw(5, 0, msg2);
+	mvprintw(2, 0, "%s", msg1);
+	mvprintw(5, 0, "%s", msg2);
 	mvprintw(9, 0, "Press the F3 key to exit or press Enter to continue.");
 
 	while ((c = getch()) !=  KEY_F(3)) {


### PR DESCRIPTION
With gcc 11.3 in Debian Unstable, compilation fails with :
```
gcc -DHAVE_CONFIG_H -I. -I./config   -Wdate-time -D_FORTIFY_SOURCE=2 -I ./common/ -I ./ela/ -I ./diags -I ./lpd/ -I /usr/include/ncurses/ -Wall -g -DDEBUG -DDEST_DIR='"/usr"' -DVERSION='"2.7.8"' -g -O2 -ffile-prefix-map=/build/ppc64-diag-NWaSwf/ppc64-diag-2.7.8=. -fstack-protector-strong -Wformat -Werror=format-security -Wall -D_FORTIFY_SOURCE=2 -fstack-protector-all -fwrapv -fPIE -Wstack-protector --param=ssp-buffer-size=1 -c -o lpd/indicator_rtas.o lpd/indicator_rtas.c
lpd/lp_diag.c: In function ‘UI_help’:
lpd/lp_diag.c:656:17: error: format not a string literal and no format arguments [-Werror=format-security]
  656 |                 mvwprintw(my_text_win, 0, 0, help1);
      |                 ^~~~~~~~~
lpd/lp_diag.c:658:17: error: format not a string literal and no format arguments [-Werror=format-security]
  658 |                 mvwprintw(my_text_win, 0, 0, help2);
      |                 ^~~~~~~~~
lpd/lp_diag.c:660:17: error: format not a string literal and no format arguments [-Werror=format-security]
  660 |                 mvwprintw(my_text_win, 0, 0, help3);
      |                 ^~~~~~~~~
lpd/lp_diag.c: In function ‘startup_window’:
lpd/lp_diag.c:1130:9: error: format not a string literal and no format arguments [-Werror=format-security]
 1130 |         mvprintw(2, 0, msg1);
      |         ^~~~~~~~
lpd/lp_diag.c:1131:9: error: format not a string literal and no format arguments [-Werror=format-security]
 1131 |         mvprintw(5, 0, msg2);
      |         ^~~~~~~~
```