### PR TITLE
Add NVMe diagnostics support

### DIFF
--- a/common/platform.c
+++ b/common/platform.c
@@ -22,6 +22,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <inttypes.h>
 
 #include "platform.h"
 
@@ -61,4 +62,65 @@ get_platform(void)
 
 	fclose(fp);
 	return rc;
+}
+
+int
+get_processor(void)
+{
+	int rc;
+
+	switch(get_pvr_ver()) {
+	case PVR_POWER4:
+	case PVR_POWER4p:
+		rc = POWER4;
+		break;
+	case PVR_POWER5:
+	case PVR_POWER5p:
+		rc = POWER5;
+		break;
+	case PVR_POWER6:
+		rc = POWER6;
+		break;
+	case PVR_POWER7:
+	case PVR_POWER7p:
+		rc = POWER7;
+		break;
+	case PVR_POWER8E:
+	case PVR_POWER8NVL:
+	case PVR_POWER8:
+		rc = POWER8;
+		break;
+	case PVR_POWER9:
+		rc = POWER9;
+		break;
+	case PVR_POWER10:
+		rc = POWER10;
+		break;
+	default:
+		rc = PROCESSOR_UNKNOWN;
+		break;
+	}
+
+	return rc;
+}
+
+uint16_t
+get_pvr_ver(void)
+{
+	uint16_t pvr_ver = 0xFFFF;
+	FILE *fp;
+	char line[LENGTH], *p;
+
+	if((fp = fopen(PLATFORM_FILE, "r")) == NULL)
+		return pvr_ver;
+
+	while (fgets(line, LENGTH, fp)) {
+		if ((p = strstr(line, "(pvr")) != NULL) {
+			if (sscanf(p, "(pvr%" SCNx16, &pvr_ver) == 1)
+				break;
+		}
+	}
+
+	fclose(fp);
+	return pvr_ver;
 }

--- a/common/platform.h
+++ b/common/platform.h
@@ -19,7 +19,23 @@
 #ifndef PLATFORM_H
 #define PLARFORM_H
 
+#include <stdint.h>
+
 #define PLATFORM_FILE	"/proc/cpuinfo"
+
+/* Values extracted from linux kernel arch/powerpc/include/asm/reg.h file */
+#define PVR_POWER4	0x0035
+#define PVR_POWER4p	0x0038
+#define PVR_POWER5	0x003A
+#define PVR_POWER5p	0x003B
+#define PVR_POWER6	0x003E
+#define PVR_POWER7	0x003F
+#define PVR_POWER7p	0x004A
+#define PVR_POWER8E	0x004B
+#define PVR_POWER8NVL	0x004C
+#define PVR_POWER8	0x004D
+#define PVR_POWER9	0x004E
+#define PVR_POWER10	0x0080
 
 enum {
 	PLATFORM_UNKNOWN = 0,
@@ -30,9 +46,25 @@ enum {
 	PLATFORM_MAX,
 };
 
+/* Keep this in ascending order of generation releases */
+enum {
+	PROCESSOR_UNKNOWN = 0,
+	POWER4,
+	POWER5,
+	POWER6,
+	POWER7,
+	POWER8,
+	POWER9,
+	POWER10,
+};
+
 extern const char *__platform_name[];
 
 extern int get_platform(void);
+
+extern int get_processor(void);
+
+extern uint16_t get_pvr_ver(void);
 
 static inline const char * __power_platform_name(int platform)
 {

--- a/diags/Makefile.am
+++ b/diags/Makefile.am
@@ -12,7 +12,10 @@ diag_encl_h_files = diags/diag_encl.h \
 encl_led_h_files = diags/encl_led.h \
 		   $(diag_common_h_files)
 
-sbin_PROGRAMS += diags/diag_encl diags/encl_led
+diag_nvme_h_files = diags/diag_nvme.h \
+		    common/platform.h
+
+sbin_PROGRAMS += diags/diag_encl diags/encl_led diags/diag_nvme
 
 diags_diag_encl_SOURCES = diags/diag_encl.c \
 			  diags/7031_D24_T24.c \
@@ -36,9 +39,15 @@ diags_encl_led_SOURCES = diags/encl_led.c \
 			 common/utils.c \
 			 $(encl_led_h_files)
 
-dist_man_MANS += diags/man/diag_encl.8 diags/man/encl_led.8
+diags_diag_nvme_SOURCES = diags/diag_nvme.c \
+			  common/platform.c \
+			  $(diag_nvme_h_files)
+diags_diag_nvme_LDADD = -lservicelog -lm
+diags_diag_nvme_CFLAGS = $(AM_CFLAGS) -Wno-stringop-truncation
 
-DIAG_CRONTAB_SCRIPT = diags/run_diag_encl
+dist_man_MANS += diags/man/diag_encl.8 diags/man/encl_led.8 diags/man/diag_nvme.8
+
+DIAG_CRONTAB_SCRIPT = diags/run_diag_encl diags/run_diag_nvme
 
 install-exec-hook-diag:
 	install -d --mode=755 $(DESTDIR)/var/log/ppc64-diag/diag_disk
@@ -49,6 +58,7 @@ INSTALL_EXEC_HOOKS += install-exec-hook-diag
 
 uninstall-hook-diags:
 	rm -f $(DESTDIR)/etc/cron.daily/run_diag_encl
+	rm -f $(DESTDIR)/etc/cron.daily/run_diag_nvme
 
 UNINSTALL_HOOKS += uninstall-hook-diags
 

--- a/diags/diag_nvme.c
+++ b/diags/diag_nvme.c
@@ -25,6 +25,7 @@
 #include <stdlib.h>
 #include <sys/utsname.h>
 #include "diag_nvme.h"
+#include "platform.h"
 
 #define ITEM_DATA_LENGTH	255
 #define MIN_HOURS_ON		720
@@ -81,6 +82,11 @@ int main(int argc, char *argv[]) {
 
 	DIR *dir;
 	struct dirent *dirent;
+
+	if (get_platform() != PLATFORM_PSERIES_LPAR || get_processor() < POWER10) {
+		fprintf(stdout, "%s is only supported in PowerVM LPARs and at least Power10 processors\n", argv[0]);
+		return 0;
+	}
 
 	static struct option long_options[] = {
 		{"dump", required_argument, NULL, 'd'},

--- a/diags/diag_nvme.c
+++ b/diags/diag_nvme.c
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2022 IBM Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,
+ * USA.
+ */
+
+#include "diag_nvme.h"
+
+/* get_smart_log_page - Get SMART data for NVMe device
+ * @fd - File descriptor index of NVMe device
+ * @nsid - Namespace ID, use 0xFFFFFFFF or 0x0 to get controller data, former is preferred
+ * @log - Address of log struct to store the SMART data
+ *
+ * Do an ioctl to retrieve SMART data for the specified NSID and NVMe device
+ *
+ * Return - ioctl return code is returned, 0 on success
+ */
+extern int get_smart_log_page(int fd, uint32_t nsid, struct nvme_smart_log_page *log) {
+	struct nvme_admin_cmd admin_cmd = {
+		.opcode = OPCODE_ADMIN_GET_LOG_PAGE,
+		.nsid = nsid,
+		.addr = (uint64_t)(uintptr_t)log,
+		.data_len = sizeof(*log),
+		.cdw10 = 0x007F0002,
+	};
+
+	return ioctl(fd, NVME_IOCTL_ADMIN_CMD, &admin_cmd);
+}

--- a/diags/diag_nvme.c
+++ b/diags/diag_nvme.c
@@ -38,6 +38,87 @@ extern int get_ibm_vpd_log_page(int fd, struct nvme_ibm_vpd *vpd) {
 	return ioctl(fd, NVME_IOCTL_ADMIN_CMD, &admin_cmd);
 }
 
+/* get_ibm_vpd_pcie - Get IBM VPD data from NVMe device PCIe
+ * @controller_name - Name of the device to retrieve VPD data from, expected format is nvme[0-9]+
+ * @vpd - Address of vpd struct to store the PCIe IBM VPD data
+ *
+ * Read vpd file in sysfs to retrieve IBM VPD data for the NVMe device
+ *
+ * Return - Return 0 on success, -1 on failure
+ */
+extern int get_ibm_vpd_pcie(char *controller_name, struct nvme_ibm_vpd *vpd) {
+	int fd;
+	char sysfs_vpd_path[PATH_MAX], keyword[3] = { '\0' };
+	uint8_t vpd_data[256], length_data[2], length_keyword, tag;
+	uint16_t length, length_parsed;
+
+	snprintf(sysfs_vpd_path,sizeof(sysfs_vpd_path), "%s/%s/device/vpd", NVME_SYS_PATH, controller_name);
+	fd = open(sysfs_vpd_path, O_RDONLY);
+	if (fd < 0) {
+		fprintf(stderr, "%s open failed: %s\n", sysfs_vpd_path, strerror(errno));
+		return -1;
+	}
+
+	do {
+		if (read(fd, &tag, 1) < 1)
+			goto read_error;
+		/* In case it is a large resource data type, length is stored in the next two bytes */
+		if (tag & 0x80) {
+			if (read(fd, length_data, 2) < 2)
+				goto read_error;
+			length = length_data[0] + (length_data[1] << 8);
+		}
+		/* It is a small resource data type, length is stored in the last three bits of tag byte */
+		else {
+			length = tag & 0x07;
+		}
+
+		switch (tag) {
+		/* Identifier String */
+		case 0x82:
+			memset(vpd_data, '\0', sizeof(vpd_data));
+			if (read(fd, vpd_data, length) < length)
+				goto read_error;
+			strncpy(vpd->description, (char *)vpd_data, sizeof(vpd->description));
+			break;
+
+		/* VPD-R */
+		case 0x90:
+		/* VPD-W */
+		case 0x91:
+			length_parsed = 0;
+			while (length_parsed < length) {
+				memset(vpd_data, '\0', sizeof(vpd_data));
+				if (read(fd, keyword, 2) < 2)
+					goto read_error;
+				if (read(fd, &length_keyword, 1) < 1)
+					goto read_error;
+				if (read(fd, vpd_data, length_keyword) < length_keyword)
+					goto read_error;
+				set_vpd_pcie_field(keyword, (char *)vpd_data, vpd);
+				length_parsed += length_keyword + 3;
+			}
+			break;
+
+		/* End Tag */
+		case 0x78:
+			break;
+		default:
+			fprintf(stderr, "Unknown tag 0x%x, PCIe VPD data processing aborted\n", tag);
+			close(fd);
+			return -1;
+		}
+	} while (tag != 0x78);
+
+	close(fd);
+	return 0;
+
+read_error:
+	fprintf(stderr, "Failed to read expected amount of data, PCIe VPD might be corrupted. Abort further processing\n");
+	close(fd);
+	return -1;
+}
+
 /* get_smart_log_page - Get SMART data for NVMe device
  * @fd - File descriptor index of NVMe device
  * @nsid - Namespace ID, use 0xFFFFFFFF or 0x0 to get controller data, former is preferred
@@ -57,4 +138,60 @@ extern int get_smart_log_page(int fd, uint32_t nsid, struct nvme_smart_log_page 
 	};
 
 	return ioctl(fd, NVME_IOCTL_ADMIN_CMD, &admin_cmd);
+}
+
+/* set_vpd_pcie_field - Set the appropriate field with VPD information collected
+ * @keyword - Address of keyword string extracted from PCIe VPD for a device
+ * @vpd_data - Address of vpd data string extracted from PCIe VPD for a device
+ * @vpd - Address of vpd struct to store the PCIe IBM VPD data
+ *
+ * Fill the appropriate field in the IBM VPD struct with the information collected from the PCIe VPD
+ * sysfs file for a NVMe device. This is done by mapping the keyword to the corresponding field in
+ * the struct.
+ */
+extern void set_vpd_pcie_field(const char *keyword, const char *vpd_data, struct nvme_ibm_vpd *vpd) {
+	if (!strcmp(keyword, "PN"))
+		strncpy(vpd->master_pn, vpd_data, sizeof(vpd->master_pn));
+	else if (!strcmp(keyword, "EC"))
+		strncpy(vpd->ec_level, vpd_data, sizeof(vpd->ec_level));
+	else if (!strcmp(keyword, "FN"))
+		strncpy(vpd->fru_pn, vpd_data, sizeof(vpd->fru_pn));
+	else if (!strcmp(keyword, "AN"))
+		strncpy(vpd->final_asm_pn, vpd_data, sizeof(vpd->final_asm_pn));
+	else if (!strcmp(keyword, "FC"))
+		strncpy(vpd->feature_code, vpd_data, sizeof(vpd->feature_code));
+	else if (!strcmp(keyword, "CC"))
+		strncpy(vpd->ccin, vpd_data, sizeof(vpd->ccin));
+	else if (!strcmp(keyword, "SN"))
+		strncpy(vpd->sn_11s, vpd_data, sizeof(vpd->sn_11s));
+	else if (!strcmp(keyword, "Z0"))
+		strncpy(vpd->pcie_ssid, vpd_data, sizeof(vpd->pcie_ssid));
+	else if (!strcmp(keyword, "Z1"))
+		strncpy(vpd->endurance, vpd_data, sizeof(vpd->endurance));
+	else if (!strcmp(keyword, "Z2"))
+		strncpy(vpd->capacity, vpd_data, sizeof(vpd->capacity));
+	else if (!strcmp(keyword, "Z3"))
+		strncpy(vpd->warranty, vpd_data, sizeof(vpd->warranty));
+	else if (!strcmp(keyword, "Z4"))
+		strncpy(vpd->encryption, vpd_data, sizeof(vpd->encryption));
+	else if (!strcmp(keyword, "Z5"))
+		strncpy(vpd->rctt, vpd_data, sizeof(vpd->rctt));
+	else if (!strcmp(keyword, "Z6"))
+		strncpy(vpd->load_id, vpd_data, sizeof(vpd->load_id));
+	else if (!strcmp(keyword, "Z7"))
+		strncpy(vpd->mfg_location, vpd_data, sizeof(vpd->mfg_location));
+	else if (!strcmp(keyword, "Z8"))
+		strncpy(vpd->ffc_led, vpd_data, sizeof(vpd->ffc_led));
+	else if (!strcmp(keyword, "Z9"))
+		strncpy(vpd->system_io_cmd_timeout, vpd_data, sizeof(vpd->system_io_cmd_timeout));
+	else if (!strcmp(keyword, "ZA"))
+		strncpy(vpd->format_cmd_timeout, vpd_data, sizeof(vpd->format_cmd_timeout));
+	else if (!strcmp(keyword, "ZB"))
+		strncpy(vpd->number_io_queues, vpd_data, sizeof(vpd->number_io_queues));
+	else if (!strcmp(keyword, "ZC"))
+		strncpy(vpd->flash_type, vpd_data, sizeof(vpd->flash_type));
+	else if (!strcmp(keyword, "MN"))
+		strncpy(vpd->manufacture_sn, vpd_data, sizeof(vpd->manufacture_sn));
+	else if (!strcmp(keyword, "RM"))
+		strncpy(vpd->firmware_level, vpd_data, sizeof(vpd->firmware_level));
 }

--- a/diags/diag_nvme.c
+++ b/diags/diag_nvme.c
@@ -19,6 +19,25 @@
 
 #include "diag_nvme.h"
 
+/* get_ibm_vpd_log_page - Get IBM VPD data from NVMe device log page
+ * @fd - File descriptor index of NVMe device
+ * @vpd - Address of vpd struct to store the IBM VPD data
+ *
+ * Do an ioctl to retrieve VPD data for the specified NVMe device log page 0xF1
+ *
+ * Return - ioctl return code is returned, 0 on success
+ */
+extern int get_ibm_vpd_log_page(int fd, struct nvme_ibm_vpd *vpd) {
+        struct nvme_admin_cmd admin_cmd = {
+                .opcode = OPCODE_ADMIN_GET_LOG_PAGE,
+                .addr = (uint64_t)(uintptr_t)vpd,
+                .data_len = sizeof(*vpd),
+                .cdw10 = 0x00FF00F1,
+        };
+
+	return ioctl(fd, NVME_IOCTL_ADMIN_CMD, &admin_cmd);
+}
+
 /* get_smart_log_page - Get SMART data for NVMe device
  * @fd - File descriptor index of NVMe device
  * @nsid - Namespace ID, use 0xFFFFFFFF or 0x0 to get controller data, former is preferred

--- a/diags/diag_nvme.h
+++ b/diags/diag_nvme.h
@@ -26,6 +26,42 @@
 
 #define OPCODE_ADMIN_GET_LOG_PAGE	0x02
 
+/* Struct representing IBM VPD information retrieved from Log Page 0xF1. */
+struct nvme_ibm_vpd {
+	char version[4];
+	char description[40];
+	char master_pn[12];
+	char ec_level[10];
+	char fru_pn[12];
+	char final_asm_pn[12];
+	char feature_code[4];
+	char ccin[4];
+	char sn_11s[8];
+	char pcie_ssid[8];
+	char endurance[4];
+	char capacity[10];
+	char warranty[12];
+	char encryption[1];
+	char rctt[2];
+	char load_id[8];
+	char mfg_location[3];
+	char ffc_led[5];
+	char system_io_cmd_timeout[2];
+	char format_cmd_timeout[4];
+	char number_io_queues[4];
+	char flash_type[2];
+	char manufacture_sn[20];
+	char firmware_level[8];
+	uint8_t async_firmware_commit;
+	uint8_t query_lba_map_status;
+	uint8_t query_storage_usage;
+	uint8_t async_format_nvm;
+	uint16_t endurance_value;
+	uint16_t sanitize_cmd_timeout;
+	uint8_t dsm_io_hints_supported;
+	uint8_t reserved[816];
+} __attribute__((packed));
+
 /* Struct representing the SMART / health information log page as defined in NVMe base specification */
 struct nvme_smart_log_page {
 	uint8_t critical_warning;
@@ -71,6 +107,7 @@ struct nvme_smart_log_page {
 	uint8_t reserved232[280];
 } __attribute__((packed));
 
+extern int get_ibm_vpd_log_page(int fd, struct nvme_ibm_vpd *vpd);
 extern int get_smart_log_page(int fd, uint32_t nsid, struct nvme_smart_log_page *log);
 
 #endif /* _DIAG_NVME_H */

--- a/diags/diag_nvme.h
+++ b/diags/diag_nvme.h
@@ -30,6 +30,8 @@
 #include <sys/ioctl.h>
 #include <unistd.h>
 
+#define DEVICE_TREE_PATH		"/sys/firmware/devicetree/base"
+#define LOCATION_LENGTH			80
 #define NVME_SYS_PATH			"/sys/class/nvme"
 #define OPCODE_ADMIN_GET_LOG_PAGE	0x02
 
@@ -122,6 +124,7 @@ struct nvme_smart_log_page {
 extern int get_ibm_vpd_log_page(int fd, struct nvme_ibm_vpd *vpd);
 extern int get_ibm_vpd_pcie(char *controller_name, struct nvme_ibm_vpd *vpd);
 extern int get_smart_log_page(int fd, uint32_t nsid, struct nvme_smart_log_page *log);
+extern int location_code_nvme(char *location, char *controller_name);
 extern void set_vpd_pcie_field(const char *keyword, const char *vpd_data, struct nvme_ibm_vpd *vpd);
 
 #endif /* _DIAG_NVME_H */

--- a/diags/diag_nvme.h
+++ b/diags/diag_nvme.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2022 IBM Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,
+ * USA.
+ */
+
+#ifndef _DIAG_NVME_H
+#define _DIAG_NVME_H
+
+#include <linux/nvme_ioctl.h>
+#include <stdint.h>
+#include <sys/ioctl.h>
+
+#define OPCODE_ADMIN_GET_LOG_PAGE	0x02
+
+/* Struct representing the SMART / health information log page as defined in NVMe base specification */
+struct nvme_smart_log_page {
+	uint8_t critical_warning;
+#define CRIT_WARN_SPARE		0x01
+#define CRIT_WARN_TEMP		0x02
+#define CRIT_WARN_DEGRADED	0x04
+#define CRIT_WARN_RO		0x08
+#define CRIT_WARN_VOLATILE_MEM	0x10
+#define CRIT_WARN_PMR_RO	0x20
+	uint16_t composite_temp;
+	uint8_t avail_spare;
+	uint8_t avail_spare_threshold;
+	uint8_t percentage_used;
+	uint8_t endurance_group_crit_warn_summary;
+#define EGCWS_SPARE		0x01
+#define EGCWS_DEGRADED		0x04
+#define EGCWS_RO		0x08
+	uint8_t reserved7[25];
+	uint8_t data_units_read[16];
+	uint8_t data_units_written[16];
+	uint8_t host_reads_cmd[16];
+	uint8_t host_writes_cmd[16];
+	uint8_t ctrl_busy_time[16];
+	uint8_t power_cycles[16];
+	uint8_t power_on_hours[16];
+	uint8_t unsafe_shutdowns[16];
+	uint8_t media_data_integrity_err[16];
+	uint8_t num_err_info_log_entries[16];
+	uint32_t warn_composite_temp_time;
+	uint32_t crit_composite_temp_time;
+	uint16_t temp_sensor1;
+	uint16_t temp_sensor2;
+	uint16_t temp_sensor3;
+	uint16_t temp_sensor4;
+	uint16_t temp_sensor5;
+	uint16_t temp_sensor6;
+	uint16_t temp_sensor7;
+	uint16_t temp_sensor8;
+	uint32_t thrm_mgmt_temp1_trans_count;
+	uint32_t thrm_mgmt_temp2_trans_count;
+	uint32_t total_time_thm_mgmt_temp1;
+	uint32_t total_time_thm_mgmt_temp2;
+	uint8_t reserved232[280];
+} __attribute__((packed));
+
+extern int get_smart_log_page(int fd, uint32_t nsid, struct nvme_smart_log_page *log);
+
+#endif /* _DIAG_NVME_H */

--- a/diags/diag_nvme.h
+++ b/diags/diag_nvme.h
@@ -28,12 +28,17 @@
 #include <stdio.h>
 #include <string.h>
 #include <sys/ioctl.h>
+#include <sys/stat.h>
 #include <unistd.h>
 
+#define DESCR_LENGTH			1024
 #define DEVICE_TREE_PATH		"/sys/firmware/devicetree/base"
 #define LOCATION_LENGTH			80
+#define MAX_TIME			127
+#define NVME_DEV_PATH			"/dev/nvme"
 #define NVME_SYS_PATH			"/sys/class/nvme"
 #define OPCODE_ADMIN_GET_LOG_PAGE	0x02
+#define VPD_NOT_READY			0x00F3
 
 /* Struct representing IBM VPD information retrieved from Log Page 0xF1.
  * This struct is also reutilized for PCIe VPD information in case Log Page 0xF1 is not supported.
@@ -125,6 +130,7 @@ extern int get_ibm_vpd_log_page(int fd, struct nvme_ibm_vpd *vpd);
 extern int get_ibm_vpd_pcie(char *controller_name, struct nvme_ibm_vpd *vpd);
 extern int get_smart_log_page(int fd, uint32_t nsid, struct nvme_smart_log_page *log);
 extern int location_code_nvme(char *location, char *controller_name);
+extern int open_nvme(char *dev_path);
 extern void set_vpd_pcie_field(const char *keyword, const char *vpd_data, struct nvme_ibm_vpd *vpd);
 
 #endif /* _DIAG_NVME_H */

--- a/diags/diag_nvme.h
+++ b/diags/diag_nvme.h
@@ -135,6 +135,7 @@ struct nvme_smart_log_page {
 	uint8_t reserved232[280];
 } __attribute__((packed));
 
+extern int dump_smart_data(char *device_name, char *dump_path);
 extern int get_ibm_vpd_log_page(int fd, struct nvme_ibm_vpd *vpd);
 extern int get_ibm_vpd_pcie(char *controller_name, struct nvme_ibm_vpd *vpd);
 extern int get_smart_log_page(int fd, uint32_t nsid, struct nvme_smart_log_page *log);
@@ -142,5 +143,6 @@ extern int location_code_nvme(char *location, char *controller_name);
 extern int open_nvme(char *dev_path);
 extern int read_file_dict(char *file_name, struct dictionary *dict, int max_params);
 extern void set_vpd_pcie_field(const char *keyword, const char *vpd_data, struct nvme_ibm_vpd *vpd);
+extern void write_smart_file(FILE *fp, struct nvme_smart_log_page *log);
 
 #endif /* _DIAG_NVME_H */

--- a/diags/diag_nvme.h
+++ b/diags/diag_nvme.h
@@ -24,6 +24,7 @@
 #include <fcntl.h>
 #include <linux/limits.h>
 #include <linux/nvme_ioctl.h>
+#include <math.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
@@ -138,10 +139,12 @@ struct nvme_smart_log_page {
 extern int dump_smart_data(char *device_name, char *dump_path);
 extern int get_ibm_vpd_log_page(int fd, struct nvme_ibm_vpd *vpd);
 extern int get_ibm_vpd_pcie(char *controller_name, struct nvme_ibm_vpd *vpd);
+extern int get_smart_file(char *file_path, struct nvme_smart_log_page *log);
 extern int get_smart_log_page(int fd, uint32_t nsid, struct nvme_smart_log_page *log);
 extern int location_code_nvme(char *location, char *controller_name);
 extern int open_nvme(char *dev_path);
 extern int read_file_dict(char *file_name, struct dictionary *dict, int max_params);
+extern int set_smart_log_field(struct nvme_smart_log_page *log, struct dictionary *dict, int num_elements);
 extern void set_vpd_pcie_field(const char *keyword, const char *vpd_data, struct nvme_ibm_vpd *vpd);
 extern void write_smart_file(FILE *fp, struct nvme_smart_log_page *log);
 

--- a/diags/diag_nvme.h
+++ b/diags/diag_nvme.h
@@ -20,13 +20,25 @@
 #ifndef _DIAG_NVME_H
 #define _DIAG_NVME_H
 
+#include <errno.h>
+#include <fcntl.h>
+#include <linux/limits.h>
 #include <linux/nvme_ioctl.h>
 #include <stdint.h>
+#include <stdio.h>
+#include <string.h>
 #include <sys/ioctl.h>
+#include <unistd.h>
 
+#define NVME_SYS_PATH			"/sys/class/nvme"
 #define OPCODE_ADMIN_GET_LOG_PAGE	0x02
 
-/* Struct representing IBM VPD information retrieved from Log Page 0xF1. */
+/* Struct representing IBM VPD information retrieved from Log Page 0xF1.
+ * This struct is also reutilized for PCIe VPD information in case Log Page 0xF1 is not supported.
+ * PCIe VPD according to internal specification is a subset of VPD from Log Page 0xF1, meaning that
+ * PCIe VPD has fewer fields and their maximum lengths are lower than those from Log Page 0xF1.
+ * So reutilizing this structure shouldn't lead to any loss of information.
+ */
 struct nvme_ibm_vpd {
 	char version[4];
 	char description[40];
@@ -108,6 +120,8 @@ struct nvme_smart_log_page {
 } __attribute__((packed));
 
 extern int get_ibm_vpd_log_page(int fd, struct nvme_ibm_vpd *vpd);
+extern int get_ibm_vpd_pcie(char *controller_name, struct nvme_ibm_vpd *vpd);
 extern int get_smart_log_page(int fd, uint32_t nsid, struct nvme_smart_log_page *log);
+extern void set_vpd_pcie_field(const char *keyword, const char *vpd_data, struct nvme_ibm_vpd *vpd);
 
 #endif /* _DIAG_NVME_H */

--- a/diags/diag_nvme.h
+++ b/diags/diag_nvme.h
@@ -31,14 +31,23 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
+#define CONFIG_FILE			"/etc/ppc64-diag/diag_nvme.config"
 #define DESCR_LENGTH			1024
 #define DEVICE_TREE_PATH		"/sys/firmware/devicetree/base"
+#define KEY_LENGTH			128
 #define LOCATION_LENGTH			80
 #define MAX_TIME			127
+#define MAX_DICT_ELEMENTS		64
 #define NVME_DEV_PATH			"/dev/nvme"
 #define NVME_SYS_PATH			"/sys/class/nvme"
 #define OPCODE_ADMIN_GET_LOG_PAGE	0x02
 #define VPD_NOT_READY			0x00F3
+
+/* Struct to parse key=value settings in a file */
+struct dictionary {
+	char key[KEY_LENGTH];
+	long double value;
+};
 
 /* Struct representing IBM VPD information retrieved from Log Page 0xF1.
  * This struct is also reutilized for PCIe VPD information in case Log Page 0xF1 is not supported.
@@ -131,6 +140,7 @@ extern int get_ibm_vpd_pcie(char *controller_name, struct nvme_ibm_vpd *vpd);
 extern int get_smart_log_page(int fd, uint32_t nsid, struct nvme_smart_log_page *log);
 extern int location_code_nvme(char *location, char *controller_name);
 extern int open_nvme(char *dev_path);
+extern int read_file_dict(char *file_name, struct dictionary *dict, int max_params);
 extern void set_vpd_pcie_field(const char *keyword, const char *vpd_data, struct nvme_ibm_vpd *vpd);
 
 #endif /* _DIAG_NVME_H */

--- a/diags/man/diag_nvme.8
+++ b/diags/man/diag_nvme.8
@@ -1,0 +1,98 @@
+.\"
+.\" Copyright (C) 2022 IBM Corporation
+.\"
+.TH "DIAG_NVME" "8" "June 2022" "Linux" "PowerLinux Diagnostic Tools"
+.hy
+.SH NAME
+.PP
+diag_nvme \- diagnose NVMe devices
+.SH SYNOPSIS
+.PP
+\f[B]diag_nvme\f[] [<\f[B]nvme\f[]\f[I]n\f[] \&...>]
+.PD 0
+.P
+.PD
+\f[B]diag_nvme\f[] [\-d <\f[I]file\f[]>] [\-f <\f[I]file\f[]>]
+<\f[B]nvme\f[]\f[I]n\f[]>
+.PD 0
+.P
+.PD
+\f[B]diag_nvme\f[] --help
+.SH DESCRIPTION
+.PP
+The \f[B]diag_nvme\f[] command retrieves the SMART data from the NVMe
+device(s) specified and report failures detected through events created
+in the servicelog database.
+If no device is specified, all NVMe devices detected in the system will
+go through the diagnostics procedure.
+.PP
+The user can control which events will be reported through the
+configuration file \f[I]/etc/ppc64\-diag/diag_nvme.config\f[]
+.SH OPTIONS
+.TP
+.B \f[B]\-d\f[], \f[B]--dump\f[] \f[I]file\f[]
+Dump SMART data to the specified path and file name \f[I]file\f[].
+The SMART data is extracted from an NVMe device, so specifying one is
+mandatory if this option is selected.
+File created is in a simple key=value format.
+.RS
+.RE
+.TP
+.B \f[B]\-f\f[], \f[B]--file\f[] \f[I]file\f[]
+This option usage is for testing only.
+Use SMART data from the specified path and file name \f[I]file\f[]
+instead of device, one NVMe is mandatory if this option is selected.
+The expected format of the file is a simple key=value that is the same
+one provided with the \-d / --dump option.
+If \f[I]file\f[] is missing from the filesystem it will be treated as a
+failure to retrieve SMART data and an event will be reported.
+.RS
+.RE
+.TP
+.B \f[B]\-h\f[], \f[B]--help\f[]
+Print a help message and exit
+.RS
+.RE
+.SH EXAMPLES
+.TP
+.B \f[B]diag_nvme\f[]
+Run diagnostics in all NVMe devices detected in the system.
+.RS
+.RE
+.TP
+.B \f[B]diag_nvme nvme0 nvme1\f[]
+Run diagnostics only in nvme0 and nvme1 devices.
+.RS
+.RE
+.TP
+.B \f[B]diag_nvme \-d smart.txt nvme0\f[]
+Dump SMART data from nvme0 into file smart.txt.
+.RS
+.RE
+.TP
+.B \f[B]diag_nvme \-f smart.txt nvme0\f[]
+Read SMART data from file smart.txt and use it as health information for
+diagnostics of device nvme0.
+.RS
+.RE
+.SH REPORTING BUGS
+.PP
+Patches and issues may be submitted at
+https://github.com/power\-ras/ppc64\-diag/
+.SH FILES
+.TP
+.B \f[I]/etc/ppc64\-diag/diag_nvme.config\f[]
+Configuration file to select which events to report to the servicelog
+database.
+.RS
+.RE
+.TP
+.B \f[I]/etc/cron.daily/run_diag_nvme\f[]
+Script to run diag_nvme in the system on a daily basis.
+.RS
+.RE
+.SH SEE ALSO
+.PP
+\f[B]servicelog\f[](8)
+.SH AUTHORS
+Murilo Fossa Vicentini

--- a/diags/run_diag_nvme
+++ b/diags/run_diag_nvme
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+if [ -x /usr/sbin/diag_nvme ]; then
+	/usr/sbin/diag_nvme > /dev/null 2>&1
+fi
+
+# Exit gracefully
+exit 0

--- a/ppc64-diag.spec.in
+++ b/ppc64-diag.spec.in
@@ -82,6 +82,7 @@ mkdir -p $RPM_BUILD_ROOT/var/log/ppc64_diag/diag_disk
 %config /etc/%{name}/*
 %config /etc/rc.powerfail
 %attr(755,root,root) /etc/cron.daily/run_diag_encl
+%attr(755,root,root) /etc/cron.daily/run_diag_nvme
 %attr(755,root,root) %{_libexecdir}/%{name}/rtas_errd
 %attr(755,root,root) %{_libexecdir}/%{name}/opal_errd
 %attr(644,root,root) %{_unitdir}/rtas_errd.service

--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -4,7 +4,8 @@ PPC64_DIAG_SCRIPT = scripts/ppc64_diag_setup \
 		     scripts/ppc64_diag_migrate \
 		     scripts/servevent_parse.pl
 
-CONFIG_FILE = scripts/ppc64-diag.config
+CONFIG_FILE = scripts/ppc64-diag.config \
+	       scripts/diag_nvme.config
 
 INIT_FILES = scripts/rtas_errd scripts/opal_errd
 
@@ -26,6 +27,7 @@ uninstall-hook-scripts:
 	rm -f $(DESTDIR)/etc/ppc64-diag/ppc64_diag_migrate
 	rm -f $(DESTDIR)/etc/ppc64-diag/servevent_parse.pl
 	rm -f $(DESTDIR)/etc/ppc64-diag/ppc64-diag.config
+	rm -f $(DESTDIR)/etc/ppc64-diag/diag_nvme.config
 	rm -f $(DESTDIR)/usr/libexec/ppc64-diag/rtas_errd
 	rm -f $(DESTDIR)/usr/libexec/ppc64-diag/opal_errd
 	rm -f $(DESTDIR)/usr/lib/systemd/system/rtas_errd.service

--- a/scripts/diag_nvme.config
+++ b/scripts/diag_nvme.config
@@ -1,0 +1,16 @@
+# Configuration file to track which errors to report with diag_nvme
+# Value set to 1 means it is enabled, 0 it is disabled.
+
+# Failure to retrieve SMART log data from device
+SMART_LOG_MISSING = 1
+
+# Critical Warning bits from SMART data
+AVAILABLE_SPARE_CAPACITY = 1
+TEMPERATURE_THRESHOLD = 1
+NVM_SUBSYSTEM_RELIABILITY = 1
+MEDIA_READ_ONLY = 1
+VOLATILE_MEMORY_BACKUP = 1
+PERSISTENT_MEMORY_REGION = 1
+
+# Excessive write rate compared to device endurance
+WRITE_RATE = 1

--- a/scripts/ppc64_diag_mkrsrc
+++ b/scripts/ppc64_diag_mkrsrc
@@ -106,7 +106,7 @@ $partition_name = (split(/\./, $host_name))[0];
 
 # Retrieve partition ID from /proc/device-tree/ibm,partition-no
 if (-e "/proc/device-tree/ibm,partition-no") {
-	$partition_no = `od -An -td /proc/device-tree/ibm,partition-no | sed "s/\\s//g" 2>/dev/null`;
+	$partition_no = `od -An -td --endian=big /proc/device-tree/ibm,partition-no | sed "s/\\s//g" 2>/dev/null`;
 	chomp $partition_no;
 	if (length($partition_no) == 0) {
 		$partition_no = "000".$partition_no


### PR DESCRIPTION
The NVMe diagnostics is done by using the SMART data retrieved from at an NVMe device, the data is analyzed and depending on the health status of the device it can generate events in the servicelog database, these events might be just warnings or in case of an unrecoverable error it will log a serviceable call home event for the device. Users can control which types of events will be reported through a config file that will be checked whenever the tool is executed. The NVMe diagnostics will be automatically executed on a daily basis as part of a cron script that will be automatically installed as well. At this point this tool is restricted to run in P10 PowerVM LPARs.