### PR TITLE
Fix build error with ncurses-6.3 and exit state of opal-dump-parse -h

### DIFF
--- a/lpd/lp_diag.c
+++ b/lpd/lp_diag.c
@@ -653,11 +653,11 @@ UI_help(MENU *my_menu)
 	}
 
 	if (!strcmp(desc, "ident"))
-		mvwprintw(my_text_win, 0, 0, help1);
+		mvwprintw(my_text_win, 0, 0, "%s", help1);
 	else if (!strcmp(desc, "attn"))
-		mvwprintw(my_text_win, 0, 0, help2);
+		mvwprintw(my_text_win, 0, 0, "%s", help2);
 	else
-		mvwprintw(my_text_win, 0, 0, help3);
+		mvwprintw(my_text_win, 0, 0, "%s", help3);
 
 	wrefresh(my_text_win);
 
@@ -1127,8 +1127,8 @@ startup_window(void)
 	}
 
 	mvprintw(0, 0, "SERVICE INDICATORS VERSION %s", VERSION);
-	mvprintw(2, 0, msg1);
-	mvprintw(5, 0, msg2);
+	mvprintw(2, 0, "%s", msg1);
+	mvprintw(5, 0, "%s", msg2);
 	mvprintw(9, 0, "Press the F3 key to exit or press Enter to continue.");
 
 	while ((c = getch()) !=  KEY_F(3)) {

--- a/opal-dump-parse/opal-dump-parse.c
+++ b/opal-dump-parse/opal-dump-parse.c
@@ -462,7 +462,7 @@ int main(int argc, char *argv[])
 {
 	int opt = 0;
 
-	while ((opt = getopt(argc, argv, "lh:s:o:")) != -1) {
+	while ((opt = getopt(argc, argv, "hl:s:o:")) != -1) {
 		switch (opt) {
 		case 'l':
 			opt_mdst = 1;


### PR DESCRIPTION
the commit c425490 fixes the build error with ncuses-6.3
the  commit 7dcb537 fixes the exit status of opal-dump-parse -h

Could you please review the proposed patches and merge?

Thank you!
