### PR TITLE
opal_errd: Perform platform check on opal_errd.c

### DIFF
--- a/opal_errd/opal_errd.c
+++ b/opal_errd/opal_errd.c
@@ -49,6 +49,8 @@
 #include <time.h>
 #include <libudev.h>
 #include <sys/wait.h>
+#include <libgen.h>
+#include "platform.c"
 
 #include "opal-elog-parse/opal-elog.h"
 #include "opal-elog-parse/opal-event-data.h"
@@ -889,10 +891,18 @@ int main(int argc, char *argv[])
 	int max_info_logs = 0;
 	int max_serviceable_logs = 0;
 	int opt_max_age = 0; /* Deprecated, so doesnt matter */
+	int platform = 0;
 	const char *opt_extract_opal_dump_cmd = NULL;
 	const char *opt_max_dump = NULL;
 	const char *opt_sysfs = DEFAULT_SYSFS_PATH;
 	const char *opt_output_dir = DEFAULT_OUTPUT_DIR;
+
+	platform = get_platform();
+	if (platform != PLATFORM_POWERNV) {
+		fprintf(stderr, "%s is not supported on the %s platform\n",
+				basename(argv[0]), __power_platform_name(platform));
+		exit(0);
+	}
 
 	while ((opt = getopt(argc, argv, "De:ho:s:m:wn:a:c:")) != -1) {
 		switch (opt) {


### PR DESCRIPTION
opal_errd command is supported on PowerNV platform, but not on PowerVM pSeries LPAR platform. Perform platform check to ensure that this command runs on PowerNV platform and displays proper error message when run on LPAR.

Current error message on LPAR:
    ELOG[34223]: Error accessing sysfs: /sys/firmware/opal (2: No such file or directory)

Error message on LPAR with the patch:
    opal_errd is not supported on the PowerVM pSeries LPAR platform

Signed-off-by: Barnali Guha Thakurata <barnali@linux.ibm.com>
Signed-off-by: Seeteena Thoufeek <s1seetee@linux.vnet.ibm.com>
