### PR TITLE
opal_errd: Perform platform check on opal_errd.c

### DIFF
--- a/opal_errd/opal_errd.c
+++ b/opal_errd/opal_errd.c
@@ -49,6 +49,8 @@
 #include <time.h>
 #include <libudev.h>
 #include <sys/wait.h>
+#include <libgen.h>
+#include "platform.c"
 
 #include "opal-elog-parse/opal-elog.h"
 #include "opal-elog-parse/opal-event-data.h"
@@ -871,7 +873,7 @@ int main(int argc, char *argv[])
 	char *extract_opal_dump_cmd = NULL;
 
 	int log_options;
-
+        int platform=0;
 	struct udev *udev = NULL;
 	struct udev_monitor *udev_mon = NULL;
 	struct udev_device *udev_dev = NULL;
@@ -948,7 +950,15 @@ int main(int argc, char *argv[])
 			exit(EXIT_FAILURE);
 		}
 	}
-
+        /* platform initialization */
+        if (opt_daemon) {
+            platform = get_platform();
+            if (platform != PLATFORM_POWERNV) {
+               fprintf(stderr, "%s is not supported on the %s platform\n",
+                       basename(argv[0]), __power_platform_name(platform));
+               exit(0);
+            }
+        }
 	/* syslog initialization */
 	setlogmask(LOG_UPTO(LOG_NOTICE));
 	log_options = LOG_CONS | LOG_PID | LOG_NDELAY;


### PR DESCRIPTION
opal_errd command is supported on PowerNV platform, but not on PowerVM pSeries LPAR platform. Perform platform check to ensure that this command runs on PowerNV platform and displays proper error message when run on LPAR.

User will get the following message while running opal_errd on PowerVM pseries LPAR platform with the patch:

opal_errd is not supported on the PowerVM pSeries LPAR platform