### PR TITLE
diags/man: Man page update of diag_encl

### DIFF
--- a/diags/man/diag_encl.8
+++ b/diags/man/diag_encl.8
@@ -66,6 +66,10 @@ read diagnostic information from the file whose pathname is
 and read vital product data from the file whose pathname is
 .IR path .vpd.
 .TP
+\fB\<scsi_enclosure>\fR
+The sg device on which to operate, such as sg7; if not 
+specified, all such devices will be diagnosed
+.TP
 \fB\-h\fR or \fB\-\-help\fR
 Print a usage message and exit.
 .SH "SEE ALSO"


### PR DESCRIPTION
This patch adds a description for <scsi_enclosure> option in the man page of diag_encl.

Signed-off-by: Barnali Guha Thakurata <barnali@linux.ibm.com>