### PR TITLE
This patch changes "nvme_devices" in the help page of diag_nvme to

### DIFF
--- a/diags/diag_nvme.c
+++ b/diags/diag_nvme.c
@@ -989,9 +989,9 @@ extern int open_nvme(char *dev_path) {
 }
 
 static void print_usage(char *command) {
-	printf("Usage: %s [-h] [<nvme_devices>]\n"
+	printf("Usage: %s [-h] [<nvmen ...>]\n"
 		"\t-h or --help: print this help message\n"
-		"\t<nvme_devices>: the NVMe devices on which to operate, for\n"
+		"\t<nvmen ...>: the NVMe devices on which to operate, for\n"
 		"\t                  example nvme0; if not specified, all detected\n"
 		"\t                  nvme devices will be diagnosed\n", command);
 }


### PR DESCRIPTION
"nvmen ..." so that it matches with the naming convention in the manual page

Before patch:

diags/diag_nvme --help
Usage: diags/diag_nvme [-h] [<nvme_devices>]
        -h or --help: print this help message
        <nvme_devices>: the NVMe devices on which to operate, for
                          example nvme0; if not specified, all detected
                          nvme devices will be diagnosed

man diags/man/diag_nvme.8
...
SYNOPSIS
       diag_nvme [<nvmen ...>]
       diag_nvme <nvmen>
       diag_nvme --help
...

After patch:

diags/diag_nvme --help
Usage: diags/diag_nvme [-h] [<nvmen ...>]
        -h or --help: print this help message
        <nvmen ...>: the NVMe devices on which to operate, for
                          example nvme0; if not specified, all detected
                          nvme devices will be diagnosed

man diags/man/diag_nvme.8
...
SYNOPSIS
       diag_nvme [<nvmen ...>]
       diag_nvme <nvmen>
       diag_nvme --help
...