### PR TITLE
Added stdbool instead of old typedef to define boolean

### DIFF
--- a/ela/date.c
+++ b/ela/date.c
@@ -3,8 +3,8 @@
 #include <stdio.h>
 #include <time.h>
 #include <string.h>
+#include <stdbool.h>
 
-typedef enum { false, true } bool;
 static int cur_year = 0;	// year - 1900
 static time_t end_of_cur_year;	// January 1 00:00:00 of next year
 


### PR DESCRIPTION
Got below mentioned error while building ppc64-diag package on fedora, issue was traditional way of defining **bool** using **typedef**. 

Following is the error: 

```
In file included from ./common/platform.c:27,
                 from ela/explain_syslog.cpp:15:
./common/platform.h:19: warning: header guard ‘PLATFORM_H’ followed by ‘#define’ of a different macro [-Wheader-guard]
   19 | #ifndef PLATFORM_H
./common/platform.h:20: note: ‘PLARFORM_H’ is defined here; did you mean ‘PLATFORM_H’?
   20 | #define PLARFORM_H
ela/date.c:7:16: error: cannot use keyword ‘false’ as enumeration constant
    7 | typedef enum { false, true } bool;
      |                ^~~~~
ela/date.c:7:16: note: ‘false’ is a keyword with ‘-std=c23’ onwards
ela/date.c:7:30: error: expected ‘;’, identifier or ‘(’ before ‘bool’
    7 | typedef enum { false, true } bool;
      |                              ^~~~
ela/date.c:7:30: warning: useless type name in empty declaration
make: *** [Makefile:2173: ela/date.o] Error 1
make: *** Waiting for unfinished jobs....
RPM build errors:
error: Bad exit status from /var/tmp/rpm-tmp.3BFNWG (%build)
    Bad exit status from /var/tmp/rpm-tmp.3BFNWG (%build)
Child return code was: 1
EXCEPTION: [Error('Command failed: \n # /usr/bin/systemd-nspawn -q -M 7ab6f6cf3b8845c98bdbe380e1b3c8d3 -D /var/lib/mock/f42-build-56462276-6543971/root -a -u mockbuild --capability=cap_ipc_lock --bind=/tmp/mock-resolv.8jynre2l:/etc/resolv.conf --bind=/dev/btrfs-control --bind=/dev/mapper/control --bind=/dev/fuse --bind=/dev/loop-control --bind=/dev/loop0 --bind=/dev/loop1 --bind=/dev/loop2 --bind=/dev/loop3 --bind=/dev/loop4 --bind=/dev/loop5 --bind=/dev/loop6 --bind=/dev/loop7 --bind=/dev/loop8 --bind=/dev/loop9 --bind=/dev/loop10 --bind=/dev/loop11 --console=pipe --setenv=TERM=vt100 --setenv=SHELL=/bin/bash --setenv=HOME=/builddir --setenv=HOSTNAME=mock --setenv=PATH=/usr/bin:/bin:/usr/sbin:/sbin \'--setenv=PROMPT_COMMAND=printf "\\033]0;<mock-chroot>\\007"\' \'--setenv=PS1=<mock-chroot> \\s-\\v\\$ \' --setenv=LANG=C.UTF-8 --resolv-conf=off bash --login -c \'/usr/bin/rpmbuild -bb --noclean --target ppc64le --nodeps /builddir/build/SPECS/ppc64-diag.spec\'\n', 1)]
Traceback (most recent call last):
  File "/usr/lib/python3.13/site-packages/mockbuild/trace_decorator.py", line 93, in trace
    result = func(*args, **kw)
  File "/usr/lib/python3.13/site-packages/mockbuild/util.py", line 610, in do_with_status
    raise exception.Error("Command failed: \n # %s\n%s" % (cmd_pretty(command, env), output), child.returncode)
mockbuild.exception.Error: Command failed: 
```
