### PR TITLE
spec: fix rpm build warning

### DIFF
--- a/ppc64-diag.spec.in
+++ b/ppc64-diag.spec.in
@@ -74,7 +74,6 @@ mkdir -p $RPM_BUILD_ROOT/var/log/ppc64_diag/diag_disk
 %doc /usr/share/man/man8/*
 /usr/sbin/*
 %dir /etc/%{name}
-%dir /etc/%{name}/ses_pages
 %dir /var/log/ppc64-diag
 %dir /var/log/ppc64-diag/diag_disk
 %dir /var/log/dump


### PR DESCRIPTION
rpmbuild -ba ppc64-diag.spec prints following warning:

RPM build warnings:
    File listed twice: /etc/ppc64-diag/ses_pages

The /etc/ppc64-diag/ses_pages is listed twice under %files.

1. %dir /etc/%{name}/ses_pages
2. %config /etc/%{name}/*

Fix it by removing the 1st entry.