### PR TITLE
README: update make command to create tarball

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ make install
 ### Building rpms
 To build a tarball to feed to rpmbuild, do
 
-`make tarball
+`make dist-gzip
 
 As an example, we use a command similar to the following:
 


### PR DESCRIPTION
make tarball target is not validate, dist-gzip is the correct make target to create a tarball.

$ make tarball
make: *** No rule to make target 'tarball'.  Stop.

Update the README.md with the correct command to create the tarball.