### PR TITLE
scripts/ppc64_diag_mkrsrc: Fix typo to avoid syntax error

### DIFF
--- a/scripts/ppc64_diag_mkrsrc
+++ b/scripts/ppc64_diag_mkrsrc
@@ -132,7 +132,7 @@ chop $cec_machinetype;
 
 $cec_machineserial = -e '/proc/device-tree/ibm,vendor-system-id' ?
 `cat /proc/device-tree/ibm,vendor-system-id | cut -c5- 2>/dev/null` :
-`cat /proc/device-tree/system-id | cut -c5- 2>/dev/null` :
+`cat /proc/device-tree/system-id | cut -c5- 2>/dev/null` ;
 
 chomp $cec_machineserial;
 chop $cec_machineserial;


### PR DESCRIPTION
A user executed the diag_nvme utility to inject an error in a disk in order to generate a servicelog event. While executing the command and after the event was logged, a syntax error was displayed for the ppc64_diag_mkrsrc script for the line with:

"`cat /proc/device-tree/system-id | cut -c5- 2>/dev/null` :"

which showed the statement terminated with a `:` rather than a `;`. The script was then aborted and did not generate a IBM.ServiceEvent RMC resource as expected.